### PR TITLE
🐛Random 404 message not working

### DIFF
--- a/frontend/src/pages/404.astro
+++ b/frontend/src/pages/404.astro
@@ -29,6 +29,8 @@ import Button from "@components/ui/Button.astro";
     "Har du hørt om 99.99% uptime? Ikke vi!",
     "Sjekk AWS US-East-1 sin status.",
     "Your majesty, they hit the second server!",
+    "Sikkert en DNS-feil.",
+    "BetaSEC har tatt ned siden pga sikkerhetsbrudd.",
   ];
 
   const randomText = messages[Math.floor(Math.random() * messages.length)];


### PR DESCRIPTION
404 nettsider ville ikke bruke random meldinger, flyttet logikken til klient siden slik at det vises på statiske websider. Kan bli flyttet når vi tenker å kjøre server side rendering for sider.

La også til noen ekstra meldinger hihi