### PR TITLE
🐛Allow Typescript check to continue on error

### DIFF
--- a/.github/workflows/dependabot-frontend.yaml
+++ b/.github/workflows/dependabot-frontend.yaml
@@ -31,6 +31,7 @@ jobs:
       - name: Run Typescript Check
         working-directory: frontend
         run: npx astro check
+        continue-on-error: true
 
       - name: Build Frontend
         working-directory: frontend


### PR DESCRIPTION
The astro check has a continue on error since it seems like it is very strict on type checking, that is why I've made it continue on error so that we get the most important error build error as the significant error on merging dependabot updates