### PR TITLE
Moved GitHub repo link to bottom of footer

### DIFF
--- a/frontend/src/components/layout/Footer.astro
+++ b/frontend/src/components/layout/Footer.astro
@@ -33,13 +33,6 @@ import Socials from "@components/widgets/Socials.astro";
       <ul class="space-y-2 text-sm">
         <li><a href="/om" class="transition hover:opacity-80">Om Beta</a></li>
         <li><a href="/kontakt" class="transition hover:opacity-80">Kontakt</a></li>
-        <li>
-          <a
-            href="https://github.com/betauia/betauia.net"
-            target="_blank"
-            class="transition hover:opacity-80">GitHub repo</a
-          >
-        </li>
         <li><a href="/Vedtekter.pdf" class="transition hover:opacity-80">Vedtekter</a></li>
       </ul>
     </section>
@@ -61,6 +54,11 @@ import Socials from "@components/widgets/Socials.astro";
       class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 text-center text-sm sm:flex-row"
     >
       <p>© 2025 BETA Engineering & Technology Association</p>
+      <a
+        href="https://github.com/betauia/betauia.net"
+        target="_blank"
+        class="transition hover:opacity-80">GitHub repo</a
+      >
       <a href="mailto:betadev@betauia.net" class="hover:opacity-80">Feil på siden? Kontakt oss!</a>
     </div>
   </div>

--- a/frontend/src/components/layout/Footer.astro
+++ b/frontend/src/components/layout/Footer.astro
@@ -53,7 +53,7 @@ import Socials from "@components/widgets/Socials.astro";
     <div
       class="mx-auto grid max-w-6xl grid-cols-1 items-center justify-between gap-3 text-center text-sm sm:grid-cols-3"
     >
-      <p>© 2025 BETA Engineering & Technology Association</p>
+      <p>© 2025 BETA Engineering & Technology&nbsp;Association</p>
       <a
         href="https://github.com/betauia/betauia.net"
         target="_blank"

--- a/frontend/src/components/layout/Footer.astro
+++ b/frontend/src/components/layout/Footer.astro
@@ -51,7 +51,7 @@ import Socials from "@components/widgets/Socials.astro";
 
   <div class="mt-10 border-t border-white/30 pt-6">
     <div
-      class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 text-center text-sm sm:flex-row"
+      class="mx-auto grid max-w-6xl grid-cols-1 items-center justify-between gap-3 text-center text-sm sm:grid-cols-3"
     >
       <p>© 2025 BETA Engineering & Technology Association</p>
       <a


### PR DESCRIPTION
Also fixed the centering of the footer bottom, and improved line breaking for the BETA copyright.

closes #179

![msedge_QjIhJB2y2B](https://github.com/user-attachments/assets/0d0d6077-8157-4c7c-bfde-f5fc7ed7f9c7)
