### PR TITLE
Fix paths of eventkom logos

### DIFF
--- a/frontend/src/data/branding.ts
+++ b/frontend/src/data/branding.ts
@@ -24,10 +24,10 @@ import bedkomBlack from "@assets/logos/bedkom/black.png";
 import bedkomBlue from "@assets/logos/bedkom/blue.png";
 import bedkomWhite from "@assets/logos/bedkom/white.png";
 
-import eventkomBase from "@assets/logos/bedkom/base.svg";
-import eventkomBlack from "@assets/logos/bedkom/black.png";
-import eventkomBlue from "@assets/logos/bedkom/blue.png";
-import eventkomWhite from "@assets/logos/bedkom/white.png";
+import eventkomBase from "@assets/logos/eventkom/base.svg";
+import eventkomBlack from "@assets/logos/eventkom/black.png";
+import eventkomBlue from "@assets/logos/eventkom/blue.png";
+import eventkomWhite from "@assets/logos/eventkom/white.png";
 
 export const logos = {
   beta: {


### PR DESCRIPTION
Made sure the paths for the eventkom logos was pointing to the right place. Was only getting the bedkom logos when clicking them:

<img width="774" height="433" alt="image" src="https://github.com/user-attachments/assets/69681529-ec95-4b77-b87c-bde17554e832" />
