### PR TITLE
Add BetaLAN to navbar

### DIFF
--- a/frontend/src/data/navBarConfig.ts
+++ b/frontend/src/data/navBarConfig.ts
@@ -106,6 +106,12 @@ export const navigationDropdowns: NavigationDropdown[] = [
         desc: "Gjør deg klar for generalforsamling eller se hva som har blitt gjort tidligere.",
         href: "/genfors",
       },
+      {
+        icon: "fa-solid:gamepad",
+        title: "BetaLAN",
+        desc: "Bli med på LAN-party og game bort eksamenssorgen hvert semmester!",
+        href: "/betalan",
+      },
     ],
   },
   {


### PR DESCRIPTION
Added this to the bar for people to more easily see. For the future, it needs to go to a more generic site with information instead of that specific LAN to easier keep it updated. Will make an issue for that soon.

<img width="360" height="150" alt="image" src="https://github.com/user-attachments/assets/c8ad75c0-23f4-44c7-b164-2060a176c5ed" />
