### PR TITLE
Add code blocks with theme and git guide

### DIFF
--- a/frontend/astro.config.mjs
+++ b/frontend/astro.config.mjs
@@ -19,6 +19,12 @@ export default defineConfig({
   markdown: {
     remarkPlugins: [remarkMath],
     rehypePlugins: [rehypeKatex],
+    syntaxHighlight: "shiki",
+    shikiConfig: {
+      theme: "github-light",
+      darkTheme: "github-dark",
+      wrap: true,
+    },
   },
   site: "https://betauia.net",
   vite: {

--- a/frontend/src/components/semantics/CodeBlock.astro
+++ b/frontend/src/components/semantics/CodeBlock.astro
@@ -1,0 +1,39 @@
+---
+import { codeToHtml } from "shiki";
+
+interface Props {
+  code?: string;
+  lang?: string;
+  "data-language"?: string;
+}
+
+const { code: codeProp, lang: langProp, "data-language": dataLang } = Astro.props;
+const lang = langProp ?? dataLang ?? "text";
+
+const raw = codeProp ?? (await Astro.slots.render("default"));
+
+const code =
+  raw
+    ?.replace(/<\/?[^>]+(>|$)/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim() ?? "";
+
+let html: string;
+try {
+  html = await codeToHtml(code, { lang, themes: { light: "github-light", dark: "github-dark" } });
+} catch {
+  html = await codeToHtml(code, {
+    lang: "text",
+    themes: { light: "github-light", dark: "github-dark" },
+  });
+}
+---
+
+<div
+  class="not-prose my-6 overflow-x-auto rounded-lg bg-bg-raised text-sm dark:bg-dark-bg-raised [&_pre]:!bg-transparent [&_pre]:p-4"
+  set:html={html}
+/>

--- a/frontend/src/components/semantics/MathBlock.astro
+++ b/frontend/src/components/semantics/MathBlock.astro
@@ -1,0 +1,44 @@
+---
+import katex from "katex";
+import "katex/dist/katex.min.css";
+
+interface Props {
+  tex?: string;
+  display?: boolean;
+}
+
+const { tex: texProp, display = false } = Astro.props;
+
+const raw = texProp ?? (await Astro.slots.render("default"));
+
+const tex =
+  raw
+    ?.replace(/<\/?[^>]+(>|$)/g, "")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&amp;/g, "&")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .trim() ?? "";
+
+let html: string;
+try {
+  html = katex.renderToString(tex, {
+    displayMode: display,
+    throwOnError: false,
+  });
+} catch {
+  html = katex.renderToString(tex, {
+    displayMode: display,
+    throwOnError: false,
+    strict: false,
+  });
+}
+---
+
+<span
+  class={display
+    ? "not-prose my-6 block overflow-x-auto rounded-lg bg-bg-raised p-4 text-sm dark:bg-dark-bg-raised"
+    : "math-inline"}
+  set:html={html}
+/>

--- a/frontend/src/components/semantics/Prose.astro
+++ b/frontend/src/components/semantics/Prose.astro
@@ -8,22 +8,27 @@ const { class: className = "" } = Astro.props;
     prose
 
     /* BASE TEXT */
-    text-fg-base
-    dark:text-dark-fg-base
+    text-fg-muted
+    dark:text-dark-fg-muted
 
-    prose-p:text-fg-base
-    dark:prose-p:text-dark-fg-base
     prose-p:leading-relaxed
-
-    prose-strong:text-fg-base
-    dark:prose-strong:text-dark-fg-base
-
-    prose-em:text-fg-muted
-    dark:prose-em:text-dark-fg-muted
 
     /* DECORATION */
     prose-hr:border-fg-muted/30
     dark:prose-hr:border-dark-fg-muted/30
+
+    prose-strong:text-fg-base
+    dark:prose-strong:text-dark-fg-base
+    [ &_strong_a]:!text-accent
+    [&_a_strong]:!text-accent
+
+    prose-em:text-fg-base
+    dark:prose-em:text-dark-fg-base
+    [ &_em_a]:!text-accent
+    [&_a_em]:!text-accent
+
+    prose-i:text-fg-base
+    dark:prose-i:text-dark-fg-base
 
     /* HEADINGS */
     prose-headings:font-sans
@@ -53,10 +58,14 @@ const { class: className = "" } = Astro.props;
 
     /* LINKS */
     prose-a:relative
-    prose-a:text-brand
+    prose-a:text-accent
     prose-a:font-medium
     prose-a:underline
     prose-a:underline-offset-4
+    [&_a]:text-accent
+    [&_a]:font-medium
+    [&_a]:underline
+    [&_a]:underline-offset-4
 
     /* LISTS */
     prose-ul:list-disc
@@ -65,26 +74,31 @@ const { class: className = "" } = Astro.props;
     dark:prose-li:marker:text-dark-fg-muted
 
     /* QUOTES */
-    prose-blockquote:border-l-brand/40
+    prose-blockquote:border-l-accent/40
     prose-blockquote:text-fg-muted
     dark:prose-blockquote:text-dark-fg-muted
     prose-blockquote:italic
 
     /* CODE */
     prose-code:font-mono
-    prose-code:text-brand
+    prose-code:text-accent-secondary
     prose-code:bg-bg-raised
     dark:prose-code:bg-dark-bg-raised
     prose-code:px-1.5
     prose-code:py-0.5
     prose-code:rounded
+    prose-code:before:content-none
+    prose-code:after:content-none
 
     prose-pre:bg-bg-raised
     dark:prose-pre:bg-dark-bg-raised
     prose-pre:text-fg-base
     dark:prose-pre:text-dark-fg-base
     prose-pre:rounded-lg
-    prose-pre:p-4
+    prose-pre:py-0
+    prose-pre:px-4
+    prose-pre:text-sm
+    
 
     /* MEDIA */
     prose-img:rounded-lg
@@ -116,6 +130,22 @@ const { class: className = "" } = Astro.props;
     prose-dd:pl-0
     prose-dd:text-fg-muted
     dark:prose-dd:text-dark-fg-muted
+
+    /* KBD */
+    prose-kbd:font-mono
+    prose-kbd:text-fg-base
+    prose-kbd:bg-bg-raised
+    prose-kbd:px-1.5
+    prose-kbd:py-0.5
+    prose-kbd:rounded
+    prose-kbd:border
+    prose-kbd:border-fg-muted/30
+    prose-kbd:shadow-none
+    prose-kbd:align-middle 
+
+    dark:prose-kbd:text-dark-fg-base
+    dark:prose-kbd:bg-dark-bg-raised
+    dark:prose-kbd:border-dark-fg-muted/30
 
     ${className}
   `}

--- a/frontend/src/components/ui/Card.astro
+++ b/frontend/src/components/ui/Card.astro
@@ -35,7 +35,7 @@ const iconName = !hasHref ? "" : isMailLink ? "fa-solid:envelope" : "fa-solid:ar
 
     {
       frame == "placeholder" && (
-        <div class="flex h-64 items-center justify-center bg-gradient-to-br from-brand/10 to-accent-secondary/10" />
+        <div class="flex h-64 items-center justify-center bg-gradient-to-br from-accent/10 to-accent-secondary/10" />
       )
     }
 

--- a/frontend/src/components/ui/StatCard.astro
+++ b/frontend/src/components/ui/StatCard.astro
@@ -8,8 +8,8 @@ interface Props {
 const { stat, title, description } = Astro.props;
 ---
 
-<div class="rounded-lg border-2 border-brand/50 bg-brand/10 p-4">
-  <div class="mb-1 text-3xl font-bold text-brand">{stat}</div>
+<div class="rounded-lg border-2 border-accent/50 bg-accent/10 p-4">
+  <div class="mb-1 text-3xl font-bold text-accent">{stat}</div>
   <div class="mb-1 font-semibold">{title}</div>
   <p class="text-sm text-fg-muted dark:text-dark-fg-muted">
     {description}

--- a/frontend/src/components/widgets/Banner.astro
+++ b/frontend/src/components/widgets/Banner.astro
@@ -10,7 +10,7 @@ const { text, link, buttonText = "Les mer!" } = Astro.props;
 
 <div
   id="banner"
-  class="fixed bottom-6 left-1/2 z-50 w-[90%] max-w-xl -translate-x-1/2 transform rounded-xl bg-brand px-6 py-4 text-white shadow-lg transition-all duration-500"
+  class="fixed bottom-6 left-1/2 z-50 w-[90%] max-w-xl -translate-x-1/2 transform rounded-xl bg-accent px-6 py-4 text-white shadow-lg transition-all duration-500"
 >
   <div class="flex items-center justify-between">
     <p class="flex items-center text-sm font-semibold sm:text-base">
@@ -18,7 +18,7 @@ const { text, link, buttonText = "Les mer!" } = Astro.props;
     </p>
     <a
       href={link}
-      class="rounded-lg bg-white px-4 py-2 text-sm font-bold text-brand shadow transition hover:bg-gray-100"
+      class="rounded-lg bg-white px-4 py-2 text-sm font-bold text-accent shadow transition hover:bg-gray-100"
     >
       {buttonText}
     </a>

--- a/frontend/src/components/widgets/Discord.astro
+++ b/frontend/src/components/widgets/Discord.astro
@@ -4,7 +4,7 @@ import { Icon } from "astro-icon/components";
 
 <a href="https://discord.gg/3xBPkDsaXy" target="_blank">
   <div
-    class="flex justify-center gap-8 rounded-2xl bg-brand px-8 py-6 text-white shadow-md transition hover:shadow-xl"
+    class="flex justify-center gap-8 rounded-2xl bg-accent px-8 py-6 text-white shadow-md transition hover:shadow-xl"
   >
     <div class="flex items-center justify-center">
       <Icon name="fa-brands:discord" class="h-16 w-16" />

--- a/frontend/src/components/widgets/Faq.astro
+++ b/frontend/src/components/widgets/Faq.astro
@@ -24,7 +24,7 @@ const { title, items } = Astro.props as Props;
             <div>{item.question}</div>
             <div>
               <Icon
-                class="text-brand transition-transform duration-300"
+                class="text-accent transition-transform duration-300"
                 name="fa-solid:angle-down"
               />
             </div>

--- a/frontend/src/components/widgets/Timeline.astro
+++ b/frontend/src/components/widgets/Timeline.astro
@@ -33,10 +33,10 @@ const { title, items } = Astro.props as Props;
                 <div class="flex h-[2rem] items-center whitespace-nowrap rounded-l-lg bg-gray-600 px-2 text-sm font-bold">
                   {item.when}
                 </div>
-                <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-brand pl-2 pr-1 text-lg font-bold">
+                <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-accent pl-2 pr-1 text-lg font-bold">
                   {item.title}
                 </h4>
-                <div class="h-0 w-0 border-b-[1rem] border-l-[1rem] border-t-[1rem] border-b-transparent border-l-brand border-t-transparent" />
+                <div class="h-0 w-0 border-b-[1rem] border-l-[1rem] border-t-[1rem] border-b-transparent border-l-accent border-t-transparent" />
               </a>
               <div class="my-2 mr-8 text-right">
                 <p class="opacity-80">{item.where}</p>
@@ -48,7 +48,7 @@ const { title, items } = Astro.props as Props;
 
         {/* Line */}
         <div class="flex flex-col items-center justify-evenly">
-          <div class="mt-2 h-4 w-4 rounded-full bg-brand" />
+          <div class="mt-2 h-4 w-4 rounded-full bg-accent" />
           <div class="mt-2 flex-1 border-2 border-gray-600" />
         </div>
 
@@ -60,8 +60,8 @@ const { title, items } = Astro.props as Props;
                 href={item.link}
                 class="flex items-center pl-4 text-white transition hover:opacity-75"
               >
-                <div class="h-0 w-0 border-b-[1rem] border-r-[1rem] border-t-[1rem] border-b-transparent border-r-brand border-t-transparent" />
-                <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-brand pl-1 pr-2 text-lg font-bold">
+                <div class="h-0 w-0 border-b-[1rem] border-r-[1rem] border-t-[1rem] border-b-transparent border-r-accent border-t-transparent" />
+                <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-accent pl-1 pr-2 text-lg font-bold">
                   {item.title}
                 </h4>
                 <div class="flex h-[2rem] items-center whitespace-nowrap rounded-r-lg bg-gray-600 px-2 text-sm font-bold">
@@ -81,8 +81,8 @@ const { title, items } = Astro.props as Props;
               href={item.link}
               class="flex items-center pl-4 text-white transition hover:opacity-75"
             >
-              <div class="h-0 w-0 border-b-[1rem] border-r-[1rem] border-t-[1rem] border-b-transparent border-r-brand border-t-transparent" />
-              <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-brand pl-1 pr-2 text-lg font-bold">
+              <div class="h-0 w-0 border-b-[1rem] border-r-[1rem] border-t-[1rem] border-b-transparent border-r-accent border-t-transparent" />
+              <h4 class="flex h-[2rem] items-center whitespace-nowrap bg-accent pl-1 pr-2 text-lg font-bold">
                 {item.title}
               </h4>
               <div class="flex h-[2rem] items-center whitespace-nowrap rounded-r-lg bg-gray-600 px-2 text-sm font-bold">
@@ -99,6 +99,6 @@ const { title, items } = Astro.props as Props;
     ))
   }
   <div class="flex justify-start md:justify-center">
-    <Icon class="text-2xl text-brand" name="fa-solid:caret-down" />
+    <Icon class="text-2xl text-accent" name="fa-solid:caret-down" />
   </div>
 </div>

--- a/frontend/src/components/widgets/UiACTFDiscord.astro
+++ b/frontend/src/components/widgets/UiACTFDiscord.astro
@@ -4,7 +4,7 @@ import { Icon } from "astro-icon/components";
 
 <a href="https://discord.gg/eZEm53BB7A" target="_blank">
   <div
-    class="bg-brand-red flex justify-center gap-8 rounded-2xl px-8 py-6 text-white shadow-md transition hover:shadow-xl"
+    class="flex justify-center gap-8 rounded-2xl bg-red-700 px-8 py-6 text-white shadow-md transition hover:shadow-xl"
   >
     <div class="flex items-center justify-center">
       <Icon name="fa-brands:discord" class="h-16 w-16" />

--- a/frontend/src/data/branding.ts
+++ b/frontend/src/data/branding.ts
@@ -99,7 +99,7 @@ export const brandingColors = [
     name: "Muted",
     description: "Nedtonet tekstfarge for mindre viktig informasjon.",
     light: "#425269",
-    dark: "#A1B1D1",
+    dark: "#B9C5DD",
   },
   {
     name: "Aksent (primær)",

--- a/frontend/src/data/navBarConfig.ts
+++ b/frontend/src/data/navBarConfig.ts
@@ -107,6 +107,12 @@ export const navigationDropdowns: NavigationDropdown[] = [
         href: "/genfors",
       },
       {
+        icon: "fa-brands:git-alt",
+        title: "Git Guide",
+        desc: "Let frem hva enn spørsmål du har om Git i cheat sheeten med tips.",
+        href: "/guides/git",
+      },
+      {
         icon: "fa-solid:gamepad",
         title: "BetaLAN",
         desc: "Bli med på LAN-party og game bort eksamenssorgen hvert semmester!",

--- a/frontend/src/layouts/MarkdownLayout.astro
+++ b/frontend/src/layouts/MarkdownLayout.astro
@@ -1,15 +1,16 @@
 ---
 import PageLayout from "@layouts/BaseLayout.astro";
 import Container from "@components/layout/Container.astro";
+import Prose from "@components/semantics/Prose.astro";
 
 const { frontmatter } = Astro.props;
 ---
 
 <PageLayout title={frontmatter.title}>
   <Container>
-    <div class="md-content">
+    <Prose>
       <h1 class="my-0 mb-0">{frontmatter.title}</h1>
       <slot />
-    </div>
+    </Prose>
   </Container>
 </PageLayout>

--- a/frontend/src/pages/betadev/gamejam/index.astro
+++ b/frontend/src/pages/betadev/gamejam/index.astro
@@ -46,7 +46,7 @@ import BaseLayout from "@layouts/BaseLayout.astro";
 
     <p class="mt-4">
       Questions? Ask current BETADEV leader on discord <code>@myrstad_</code> or ask in BETA's <a
-        class="bg-brand p-1 text-white"
+        class="bg-accent p-1 text-white"
         href="https://discord.gg/3xBPkDsaXy">discord server</a
       >.
     </p>

--- a/frontend/src/pages/genfors/index.astro
+++ b/frontend/src/pages/genfors/index.astro
@@ -12,7 +12,7 @@ import Prose from "@components/semantics/Prose.astro";
   <Container>
     <Prose>
       <h1>
-        Generalforsamlingen i <span class="text-brand">BETA</span>
+        Generalforsamlingen i <span class="text-accent">BETA</span>
       </h1>
 
       <h2>Hva er generalforsamlingen?</h2>
@@ -22,9 +22,10 @@ import Prose from "@components/semantics/Prose.astro";
         avgjørelser for Beta tas.
       </p>
 
-      <p><b>Frister:</b> fra og med generalforsamlingen 2027 skal generalforsamlingen annonseres
-        to (2) uker før dato med en midlertidig agenda. Innen én (1) uke før generalforsamlingen 
-        skal fullstendig agenda med saker som skal behandles legges ut.
+      <p>
+        <b>Frister:</b> fra og med generalforsamlingen 2027 skal generalforsamlingen annonseres to (2)
+        uker før dato med en midlertidig agenda. Innen én (1) uke før generalforsamlingen skal fullstendig
+        agenda med saker som skal behandles legges ut.
       </p>
 
       <p><i>Alle medlemmer har stemmerett!</i></p>
@@ -69,8 +70,5 @@ import Prose from "@components/semantics/Prose.astro";
         text="Referatet fra 2025. Lyst til å lage en arkiv side, sjekk ut GitHuben til BETA eller kontakt BetaDEV!"
       />
     </div>
-   
-
-  
   </Container>
 </BaseLayout>

--- a/frontend/src/pages/guides/git.mdx
+++ b/frontend/src/pages/guides/git.mdx
@@ -3,6 +3,10 @@ layout: src/layouts/MarkdownLayout.astro
 title: Git-guide
 ---
 
+import CodeBlock from "@components/semantics/CodeBlock.astro";
+
+export const components = { pre: CodeBlock };
+
 ## Introduksjon
 
 Git er et versjonskontrollsystem som hjelper deg med å holde styr på kode, samarbeide med andre og rulle tilbake til tidligere versjoner om noe går galt.
@@ -512,7 +516,7 @@ For å holde prosjekter ryddig og gjøre samarbeid enklere, er det viktig å fø
 
 Filen er ganske greie å skrive, og gjelder kun for mappen den ligger i og alle undermapper. Du skriver filnavn inn for å ikke inkludere med et par spesielle tegn:
 
-```gitignore
+```
 # Bruk `#` for en vakker kommentar
 
 # Ikke inkluder `.env` og `node_modules` mappen
@@ -855,7 +859,7 @@ git rm --cached filnavn    # Fjern fil fra Git, behold lokalt
 git rm --cached -r mappe/  # Fjern mappe fra Git
 ```
 
-```gitignore
+```
 # Bruk `#` for en vakker kommentar
 .env            # Ikke inkluder fil
 node_modules/   # Ikke inkluder mappe

--- a/frontend/src/pages/index.astro
+++ b/frontend/src/pages/index.astro
@@ -6,6 +6,8 @@ import BetaLogo from "@assets/logos/beta/base.svg";
 
 import Banner from "@components/widgets/Banner.astro";
 import HeroBackground from "@components/fun/HeroBackground.svelte";
+import CodeBlock from "@components/semantics/CodeBlock.astro";
+import Prose from "@components/semantics/Prose.astro";
 
 const showBanner = false;
 const bannerText = "";
@@ -16,7 +18,7 @@ const bannerLink = "/";
   <Container class="flex min-h-svh flex-col justify-center">
     <div class="flex h-full items-center">
       <div>
-        <BetaLogo class="h-24 text-brand" />
+        <BetaLogo class="h-24 text-accent" />
         <h1 class="mt-4 text-4xl font-semibold">Linjeforeningen for datastudenter</h1>
         <p class="mt-2 max-w-2xl text-fg-muted dark:text-dark-fg-muted">
           Beta er linjeforeningen for studenter innen cybersikkerhet, dataingeniør, IKT eller

--- a/frontend/src/pages/om/index.astro
+++ b/frontend/src/pages/om/index.astro
@@ -18,10 +18,10 @@ import Card from "@components/ui/Card.astro";
   <Container>
     <div class="mx-auto mt-6 max-w-3xl text-center">
       <div class="mb-4 flex justify-center">
-        <BetaLogo class="h-20 text-brand" />
+        <BetaLogo class="h-20 text-accent" />
       </div>
       <h1 class="mb-3 text-4xl font-bold">
-        Linjeforening for <span class="text-brand">datastudenter</span>
+        Linjeforening for <span class="text-accent">datastudenter</span>
       </h1>
       <p class="mx-auto mb-6 max-w-2xl text-lg text-fg-muted dark:text-dark-fg-muted">
         Beta er linjeforeningen ved UiA Grimstad for cybersikkerhet, dataingeniør, IKT og kunstig

--- a/frontend/src/pages/workshop/git.astro
+++ b/frontend/src/pages/workshop/git.astro
@@ -13,7 +13,7 @@ import { Icon } from "astro-icon/components";
     <h1
       class="mb-4 flex gap-4 border-b-2 border-gray-600 pb-4 text-4xl font-bold dark:border-gray-400"
     >
-      Git Workshop <Icon name="fa-solid:code-branch" class="text-brand" />
+      Git Workshop <Icon name="fa-solid:code-branch" class="text-accent" />
     </h1>
     <p class="my-4">
       <b
@@ -28,7 +28,7 @@ import { Icon } from "astro-icon/components";
     <div class="mb-8 mt-8">
       <a href="https://forms.cloud.microsoft/e/z2JEkxBUxr" target="_blank">
         <div
-          class="flex justify-center gap-8 rounded-2xl bg-brand px-8 py-6 text-white shadow-md transition hover:shadow-xl"
+          class="flex justify-center gap-8 rounded-2xl bg-accent px-8 py-6 text-white shadow-md transition hover:shadow-xl"
         >
           <div class="flex items-center justify-center">
             <Icon name="fa-solid:file-signature" class="h-16 w-16" />
@@ -57,7 +57,7 @@ import { Icon } from "astro-icon/components";
       til de mest spesielle konseptene som:
     </p>
 
-    <ul class="ml-6 list-[square] space-y-2 marker:text-brand">
+    <ul class="ml-6 list-[square] space-y-2 marker:text-accent">
       <li><b>Hva Git er og hva som egentlig skjer bak panseret</b></li>
       <li><b>De vanligste kommandoene for daglig bruk</b></li>
       <li><b>Undoing, fiksing og hvordan endre historien</b></li>
@@ -69,7 +69,7 @@ import { Icon } from "astro-icon/components";
 
     <p class="my-4">
       Eneste du trenger er en laptop, så husk å <a
-        class="text-brand underline"
+        class="text-accent underline"
         href="https://git-scm.com/downloads">installere Git</a
       > før tirsdag og pass på at du er bittelitt kjent med terminalen. Alt vil foregå uten fancy interface
       i terminal slik at du faktisk vet ser hva som foregår.
@@ -77,7 +77,7 @@ import { Icon } from "astro-icon/components";
 
     <p class="my-8 font-bold">
       Om det er noen spørsmål, ta kontakt med @jokko4 på <a
-        class="text-brand underline"
+        class="text-accent underline"
         href="https://discord.gg/3xBPkDsaXy"
         >Beta sin Discord
       </a>! Vi snakkes!

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -17,175 +17,7 @@
 
   /* Prose links */
   .prose a {
-    @apply decoration-brand/40 transition-colors hover:decoration-brand;
-  }
-
-  /* --------------------------- */
-  /* Layout for markdown content */
-  /* --------------------------- */
-
-  /* Headers */
-  .md-content h1 {
-    @apply mb-4 border-b-2 border-gray-900 border-opacity-25 pb-2 text-4xl font-bold dark:border-white dark:border-opacity-25;
-  }
-  .md-content h2 {
-    @apply mb-3 mt-6 text-3xl font-semibold;
-  }
-  .md-content h3 {
-    @apply mb-3 mt-4 text-2xl;
-  }
-  .md-content h4 {
-    @apply mb-2 mt-3 text-xl;
-  }
-  .md-content h5 {
-    @apply mb-1 mt-2 text-lg;
-  }
-  .md-content h6 {
-    @apply mb-1 mt-2 text-base;
-  }
-
-  .md-content h1,
-  .md-content h2,
-  .md-content h3,
-  .md-content h4,
-  .md-content h5,
-  .md-content h6 {
-    @apply font-semibold leading-normal;
-  }
-
-  /* Text */
-
-  .md-content p {
-    @apply mb-4 text-base;
-  }
-
-  .md-content a {
-    @apply text-brand underline duration-100 ease-linear hover:opacity-75;
-  }
-
-  /* Lists */
-
-  .md-content :not(li) > ul,
-  .md-content :not(li) > ol {
-    @apply mb-4;
-  }
-
-  .md-content ul {
-    @apply list-[square] marker:text-base marker:text-brand;
-  }
-
-  .md-content > ul {
-    @apply mb-4;
-  }
-
-  .md-content ol {
-    @apply list-decimal marker:font-bold;
-  }
-
-  .md-content li {
-    @apply ml-6 pl-1 text-base;
-  }
-
-  /* Other */
-
-  .md-content p > img {
-    @apply rounded-xl;
-  }
-
-  .md-content :not(pre) > code {
-    @apply rounded px-1.5 py-0.5;
-  }
-
-  .md-content pre:has(code) {
-    @apply mb-4 text-wrap rounded-lg px-6 py-4;
-  }
-
-  .md-content hr {
-    @apply my-8 h-[2px] border-none bg-gray-900 opacity-25 dark:bg-white;
-  }
-
-  /* --------------------------- */
-  /* Layout for markdown content */
-  /* --------------------------- */
-
-  /* Headers */
-  .md-content h1 {
-    @apply mb-4 border-b-2 border-gray-900 border-opacity-25 pb-2 text-4xl font-bold dark:border-white dark:border-opacity-25;
-  }
-  .md-content h2 {
-    @apply mb-3 mt-8 text-3xl font-semibold;
-  }
-  .md-content h3 {
-    @apply mb-3 mt-8 text-2xl;
-  }
-  .md-content h4 {
-    @apply mb-2 mt-8 text-xl;
-  }
-  .md-content h5 {
-    @apply mb-1 mt-8 text-lg;
-  }
-  .md-content h6 {
-    @apply mb-1 mt-8 text-base;
-  }
-
-  .md-content h1,
-  .md-content h2,
-  .md-content h3,
-  .md-content h4,
-  .md-content h5,
-  .md-content h6 {
-    @apply font-semibold leading-normal;
-  }
-
-  /* Text */
-
-  .md-content p {
-    @apply mb-4 text-base;
-  }
-
-  .md-content a {
-    @apply text-brand underline duration-100 ease-linear hover:opacity-75;
-  }
-
-  /* Lists */
-
-  .md-content :not(li) > ul,
-  .md-content :not(li) > ol {
-    @apply mb-4;
-  }
-
-  .md-content ul {
-    @apply list-[square] marker:text-base marker:text-brand;
-  }
-
-  .md-content ol {
-    @apply list-decimal marker:font-bold;
-  }
-
-  .md-content li {
-    @apply ml-6 pl-1 text-base;
-  }
-
-  /* Other */
-
-  .md-content p > img {
-    @apply rounded-xl;
-  }
-
-  .md-content :not(pre) > code {
-    @apply rounded bg-gray-200 px-1.5 py-0.5 dark:bg-gray-800;
-  }
-
-  .md-content pre:has(code) {
-    @apply mb-4 text-wrap rounded-lg px-6 py-4;
-  }
-
-  .md-content blockquote {
-    @apply rounded border-l-4 border-brand pl-4 italic opacity-80;
-  }
-
-  .md-content hr {
-    @apply my-8 h-[2px] border-none bg-gray-900 opacity-25 dark:bg-white;
+    @apply decoration-accent/40 transition-colors hover:decoration-accent;
   }
 }
 
@@ -223,4 +55,23 @@
   clip-path: inset(50%);
   /* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
   white-space: nowrap;
+}
+
+/* Shiki */
+.shiki {
+  background: transparent !important;
+}
+
+/* Shiki dark mode */
+html.dark .shiki,
+html.dark .shiki span {
+  color: var(--shiki-dark) !important;
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
+.prose .shiki > code {
+  padding: 0 !important;
+  background: transparent !important;
 }

--- a/frontend/tailwind.config.mjs
+++ b/frontend/tailwind.config.mjs
@@ -13,7 +13,7 @@ export default {
       },
 
       colors: {
-        brand: "#0085FF",
+        // brand: "#0085FF",
         accent: {
           DEFAULT: "#0085FF",
           secondary: "#14B8A6",
@@ -26,7 +26,7 @@ export default {
 
         fg: {
           base: "#242424",
-          muted: "#425269",
+          muted: "#353F4C",
         },
 
         dark: {
@@ -37,7 +37,7 @@ export default {
 
           fg: {
             base: "#FDFDFD",
-            muted: "#A1B1D1",
+            muted: "#B9C5DD",
           },
         },
       },


### PR DESCRIPTION
Added code block component to replace regulare pre for code so it can be easily switched through js and our darkmode setter with shiki's github theme. Also made a similar component for math, so it is a bit overlap and easier to use. Here is what is typed in the markdown file and the output:

```md
---
layout: src/layouts/MarkdownLayout.astro
title: Test
---

import CodeBlock from "@components/semantics/CodeBlock.astro";
import MathBlock from "@components/semantics/MathBlock.astro";

export const components = { pre: CodeBlock, math: MathBlock };

## Test

$$
\vec{u}=[6,7]
$$

`'`bash
sudo rm -rf --no-preserve-root /
`'`
```
Note that i could not type three ` characters here...

<img width="494" height="265" alt="image" src="https://github.com/user-attachments/assets/10f2cef6-e689-4fec-8d3c-dc9b0b34e2a0" />
<img width="494" height="265" alt="image" src="https://github.com/user-attachments/assets/a9b9fb6c-72e4-44a3-8b31-72c6b3efda89" />

I also cleaned up the Prose, removed a dupe color and added the git guide to the navbar to show this off :)

Solves #138 