### PR TITLE
🐛 Fix job image path

### DIFF
--- a/frontend/src/pages/jobs/[id].astro
+++ b/frontend/src/pages/jobs/[id].astro
@@ -12,7 +12,7 @@ import { formatFullDeadline, formatJobType, formatStudy, formatYears } from "@li
 const { id } = Astro.params;
 
 const internalBackendUrl = "http://backend:8000";
-const apiBase = "http://localhost:8000";
+const apiBase = import.meta.env.PUBLIC_BACKEND_URL || "http://localhost:8000";
 
 let job = null;
 let safeBodyHtml = "";


### PR DESCRIPTION
Job image is not appearing on the posts.

Reason: image path only set to localhost, not using env

Fix: Change to use env var as in other places

<img width="1092" height="580" alt="image" src="https://github.com/user-attachments/assets/0f636032-cda6-46b7-8e78-1c3dee63444d" />